### PR TITLE
Updated smartcoop-python-sdk version to 0.1.3

### DIFF
--- a/custom_components/omlet_smart_coop/manifest.json
+++ b/custom_components/omlet_smart_coop/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/williamschey/hassio-omlet-smartcoop-door/wiki",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/williamschey/hassio-omlet-smartcoop-door/issues",
-  "requirements": ["smartcoop-python-sdk==0.1.2"],
+  "requirements": ["smartcoop-python-sdk==0.1.3"],
   "version": "0.9.5"
 }


### PR DESCRIPTION
Updated smartcoop-python-sdk to the newly release 0.1.3 to support the recently release feeder.